### PR TITLE
Fixed posterior_epred_logitnormal

### DIFF
--- a/R/logitnormal.R
+++ b/R/logitnormal.R
@@ -78,11 +78,10 @@ posterior_predict_logitnormal <- function(i, prep, ...) {
 #'
 #' @param prep BRMS data
 #'
-#' @return Mean of Posterior
+#' @return Median of Posterior
 posterior_epred_logitnormal <- function(prep) {
   mu <- brms::get_dpar(prep, "mu")
-  sigma <- brms::get_dpar(prep, "sigma")
-  return(exp(mu + sigma^2 / 2))
+  return(plogis(mu))
 }
 
 #' Custom BRMS family Logit-Normal in median parametrization.

--- a/R/logitnormal.R
+++ b/R/logitnormal.R
@@ -80,6 +80,7 @@ posterior_predict_logitnormal <- function(i, prep, ...) {
 #'
 #' @return Median of Posterior
 posterior_epred_logitnormal <- function(prep) {
+  warning("posterior_epred promises the mean, however with no analytical mean available for the logit-normal distribution, we provide the median in this case. Proceed with caution.")
   mu <- brms::get_dpar(prep, "mu")
   return(plogis(mu))
 }


### PR DESCRIPTION
`posterior_epred_logitnormal` was returning `exp(mu + sigma^2 / 2)`, which I believe is the lognormal epred, not the logitnormal epred. 

I've changed `posterior_epred_logitnormal` to now return the median link, `plogis(mu)`, and tested it with marginal effects. I now get similar marginal effects to a Beta regression, which seems right to me.